### PR TITLE
updated and fixed the sm2135 led driver component

### DIFF
--- a/esphome/components/sm2135/__init__.py
+++ b/esphome/components/sm2135/__init__.py
@@ -13,12 +13,26 @@ CODEOWNERS = ["@BoukeHaarsma23"]
 sm2135_ns = cg.esphome_ns.namespace("sm2135")
 SM2135 = sm2135_ns.class_("SM2135", cg.Component)
 
+CONF_RGB_CURRENT = "rgb_current"
+CONF_CW_CURRENT = "cw_current"
+
+DRIVE_STRENGTHS_CW = {
+10,15,20,25,30,40,45,50,55,60
+}
+
+DRIVE_STRENGTHS_RGB = {
+10,15,20,25,30,40,45
+}
+
+
 MULTI_CONF = True
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(SM2135),
         cv.Required(CONF_DATA_PIN): pins.gpio_output_pin_schema,
         cv.Required(CONF_CLOCK_PIN): pins.gpio_output_pin_schema,
+        cv.Required(CONF_RGB_CURRENT): cv.one_of(*DRIVE_STRENGTHS_RGB, int=True),
+        cv.Required(CONF_CW_CURRENT): cv.one_of(*DRIVE_STRENGTHS_CW, int=True)
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -31,3 +45,7 @@ async def to_code(config):
     cg.add(var.set_data_pin(data))
     clock = await cg.gpio_pin_expression(config[CONF_CLOCK_PIN])
     cg.add(var.set_clock_pin(clock))
+    
+    cg.add(var.set_rgb_current(config[CONF_RGB_CURRENT]))
+    cg.add(var.set_cw_current(config[CONF_CW_CURRENT]))
+    

--- a/esphome/components/sm2135/sm2135.h
+++ b/esphome/components/sm2135/sm2135.h
@@ -14,6 +14,18 @@ class SM2135 : public Component {
 
   void set_data_pin(GPIOPin *data_pin) { data_pin_ = data_pin; }
   void set_clock_pin(GPIOPin *clock_pin) { clock_pin_ = clock_pin; }
+  
+  void set_rgb_current(uint8 rgb_current) {
+   rgb_current_ = rgb_current;
+   current_mask_ = (convert_ma_to_bitmask(rgb_current_) << 4) | \
+     convert_mA_to_bitmask(cw_current_);
+  }
+  
+  void set_cw_current(uint8 cw_current) {
+   cw_current_ = cw_current;
+   current_mask_ = (convert_ma_to_bitmask(rgb_current_) << 4) | \
+     convert_mA_to_bitmask(cw_current_);
+  }
 
   void setup() override;
 
@@ -38,8 +50,11 @@ class SM2135 : public Component {
     SM2135 *parent_;
     uint8_t channel_;
   };
-
+  
  protected:
+ 
+  const uint8_t SM2135_DELAY = 4;
+ 
   void set_channel_value_(uint8_t channel, uint8_t value) {
     if (this->pwm_amounts_[channel] != value) {
       this->update_ = true;
@@ -47,36 +62,78 @@ class SM2135 : public Component {
     }
     this->pwm_amounts_[channel] = value;
   }
-  void write_bit_(bool value) {
-    this->clock_pin_->digital_write(false);
-    this->data_pin_->digital_write(value);
-    this->clock_pin_->digital_write(true);
+  
+  void Sm2135SetLow_(GPIOPin *pin) {
+    pin->digital_write(false);
+    pin->pin_mode(gpio::FLAG_OUTPUT);
+  }
+
+  void Sm2135SetHigh_(GPIOPin *pin) {
+      pin->pin_mode(gpio::FLAG_PULLUP);
+  }
+  
+  void Sm2135Start_(void) {
+    Sm2135SetLow_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetLow_(this->clock_pin_);
+  }
+
+  void Sm2135Stop_(void) {
+    Sm2135SetLow_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetHigh_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY);
+    Sm2135SetHigh_(this->data_pin_);
+    delayMicroseconds(SM2135_DELAY);
   }
 
   void write_byte_(uint8_t data) {
     for (uint8_t mask = 0x80; mask; mask >>= 1) {
-      this->write_bit_(data & mask);
+      if(mask & data) {
+        Sm2135SetHigh_(this->data_pin_);
+      } else {
+        Sm2135SetLow_(this->data_pin_);
+      }
+        
+      Sm2135SetHigh_(clock_pin_);
+      delayMicroseconds(SM2135_DELAY);
+      Sm2135SetLow_(clock_pin_);
     }
-    this->clock_pin_->digital_write(false);
-    this->data_pin_->digital_write(true);
-    this->clock_pin_->digital_write(true);
+    
+    Sm2135SetHigh_(this->data_pin_);
+    Sm2135SetHigh_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY / 2);
+//    uint8_t ack = digitalRead(this->data_pin_);
+    Sm2135SetLow_(this->clock_pin_);
+    delayMicroseconds(SM2135_DELAY / 2);
+    Sm2135SetLow_(this->data_pin_);
   }
 
   void write_buffer_(uint8_t *buffer, uint8_t size) {
+    Sm2135Start_();
+
     this->data_pin_->digital_write(false);
     for (uint32_t i = 0; i < size; i++) {
       this->write_byte_(buffer[i]);
     }
-    this->clock_pin_->digital_write(false);
-    this->clock_pin_->digital_write(true);
-    this->data_pin_->digital_write(true);
+    
+    Sm2135Stop_();
+  }
+  
+  uint8_t convert_ma_to_bitmask(uint8_t ma) {
+    return (ma-10) / 5;
   }
 
   GPIOPin *data_pin_;
   GPIOPin *clock_pin_;
+  uint8 current_mask_;
+  uint8 rgb_current_;
+  uint8 cw_current_;
   uint8_t update_channel_;
   std::vector<uint8_t> pwm_amounts_;
   bool update_{true};
+  
+
 };
 
 }  // namespace sm2135


### PR DESCRIPTION
- changed the code to reflect the current tasmota code. fixes flickering and problems with bad colors.

- added options to set the current (in mA) for white and RGB channels. Made it a requirement because wrong (too high) settings could damage the LEDs.

# What does this implement/fix?

Quick description and explanation of changes

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
